### PR TITLE
Allocate memory for JIT global variables

### DIFF
--- a/src/regression/expr.rs
+++ b/src/regression/expr.rs
@@ -12,6 +12,7 @@ fn eval(expr: Expr, globals: &Context) -> Int {
     use crate::io::{EmptyInput, IgnoreOutput};
     use crate::memory::ScopedMemory;
     use crate::sm;
+    // use crate::jit;
     use crate::statement;
     use crate::syntax::Statement;
     use crate::types::Var;
@@ -77,17 +78,16 @@ fn eval(expr: Expr, globals: &Context) -> Int {
 
     // then via JIT
     // let jit = {
-    //     let program = crate::jit::Compiler::new()
-    //         .compile(&program, crate::jit::Runtime::stdio())
-    //         .unwrap();
+    //     let mut rt = jit::Runtime::stdio();
+    //     let mut memory = Memory::new();
+    //     let program = jit::compile(&program, &mut *rt, &mut memory).unwrap();
     //     let retcode = program.run();
-    //     let jit = program.globals().load(&result_var).unwrap();
+    //     let jit = memory.load(&result_var).unwrap();
     //     assert_eq!(retcode, 0);
     //     jit
     // };
     // assert_eq!(jit, sm);
 
-    // jit
     sm
 }
 

--- a/src/regression/mod.rs
+++ b/src/regression/mod.rs
@@ -96,8 +96,9 @@ pub fn run(program: &str, stdin: &[Int], stdout: &[Int], reads: usize) {
     // let (i, o) = {
     //     let mut inputs = SharedInput::new(inputs);
     //     let mut outputs = SharedOutput::new(Vec::new());
-    //     let rt = Runtime::new(Box::new(inputs.clone()), Box::new(outputs.clone()));
-    //     let program = jit::Compiler::new().compile(&program, rt).unwrap();
+    //     let mut rt = Runtime::new(Box::new(inputs.clone()), Box::new(outputs.clone()));
+    //     let mut memory = Memory::new();
+    //     let program = jit::compile(&program, &mut *rt, &mut memory).unwrap();
     //     let retcode = program.run();
     //     let i = inputs.take();
     //     let o = outputs.take();


### PR DESCRIPTION
Closes #18 
Relevant `Memory` interface was implemented in #30 